### PR TITLE
Add `EBResponse.get_result`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ erniebot.access_token = "<access-token-for-aistudio>"
 # Create a chat completion
 response = erniebot.ChatCompletion.create(model="ernie-bot", messages=[{"role": "user", "content": "你好，请介绍下你自己"}])
 
-print(response.result)
+print(response.get_result())
 ```
 
 ### 命令行接口（CLI）
@@ -98,7 +98,7 @@ response = erniebot.ChatCompletion.create(
         "content": "我在深圳，周末可以去哪里玩？"
     }])
 
-print(response)
+print(response.get_result())
 ```
 
 ### 语义向量（Embedding）
@@ -146,7 +146,7 @@ response = erniebot.Image.create(
     height=512
 )
 
-print(response)
+print(response.get_result())
 ```
 
 <img width="512" alt="image" src="https://github.com/PaddlePaddle/ERNIE-Bot-SDK/assets/1371212/73911c97-ef42-4803-8dc6-d385486c128c">
@@ -210,7 +210,7 @@ response = erniebot.ChatCompletion.create(
         },
     }, ],
 )
-print(response)
+print(response.get_result())
 ```
 
 ## Gradio Demos

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ erniebot.access_token = "<access-token-for-aistudio>"
 # Create a chat completion
 response = erniebot.ChatCompletion.create(model="ernie-bot", messages=[{"role": "user", "content": "你好，请介绍下你自己"}])
 
-print(response.result)
+print(response.get_result())
 ```
 
 ### 命令行接口（CLI）
@@ -89,7 +89,7 @@ response = erniebot.ChatCompletion.create(
         "content": "我在深圳，周末可以去哪里玩？"
     }])
 
-print(response)
+print(response.get_result())
 ```
 
 ### 语义向量（Embedding）
@@ -113,7 +113,7 @@ response = erniebot.Embedding.create(
         "2018年深圳市各区GDP"
         ])
 
-print(response)
+print(response.get_result())
 ```
 
 大家可以登陆[文心百中体验中心](https://wenxin.baidu.com/baizhong/knowledgesearch)，体验更多大模型语义搜索的能力。
@@ -137,7 +137,7 @@ response = erniebot.Image.create(
     height=512
 )
 
-print(response)
+print(response.get_result())
 ```
 
 <img width="512" alt="image" src="https://github.com/PaddlePaddle/ERNIE-Bot-SDK/assets/1371212/73911c97-ef42-4803-8dc6-d385486c128c">
@@ -201,7 +201,7 @@ response = erniebot.ChatCompletion.create(
         },
     }, ],
 )
-print(response)
+print(response.get_result())
 ```
 
 ## Gradio Demos

--- a/docs/api_reference/chat_completion.md
+++ b/docs/api_reference/chat_completion.md
@@ -165,7 +165,7 @@ erniebot.ChatCompletion.create(**kwargs: Any)
 | usage | dict | 输入输出token统计信息。token数量采用如下公式估算：`token数 = 汉字数 + 单词数 * 1.3`。<br>`prompt_tokens`：输入token数量（含上下文拼接）；<br>`completion_tokens`：当前生成结果包含的token数量；<br>`total_tokens`：输入与输出的token总数；<br> `plugins`：插件消耗的token数量。 |
 | function_call | dict | 由模型生成的函数调用，包含函数名称和请求参数等。详见[`messages`](#messages)中的`function_call`。 |
 
-字段的访问方式有2种：假设`resp`为一个`erniebot.response.EBResponse`对象，`resp['result']`或`resp.result`均可获取`result`字段的内容。
+假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['result']`或`resp.result`均可获取`result`字段的内容。此外，使用`resp.get_result()`可以获取响应中的“主要结果”：当模型返回函数调用信息时（此时，`resp`具有`function_call`字段），`resp.get_result()`的返回结果与`resp.function_call`一致；否则，`resp.get_result()`的返回结果与`resp.result`一致，即模型给出的回复文本。
 
 ## 使用示例
 
@@ -187,10 +187,10 @@ response = erniebot.ChatCompletion.create(
 
 result = ""
 if stream:
-    for res in response:
-        result += res.result
+    for resp in response:
+        result += resp.get_result()
 else:
-    result = response.result
+    result = response.get_result()
 
 print("ERNIEBOT: ", result)
 ```

--- a/docs/api_reference/chat_completion.md
+++ b/docs/api_reference/chat_completion.md
@@ -165,7 +165,7 @@ erniebot.ChatCompletion.create(**kwargs: Any)
 | usage | dict | 输入输出token统计信息。token数量采用如下公式估算：`token数 = 汉字数 + 单词数 * 1.3`。<br>`prompt_tokens`：输入token数量（含上下文拼接）；<br>`completion_tokens`：当前生成结果包含的token数量；<br>`total_tokens`：输入与输出的token总数；<br> `plugins`：插件消耗的token数量。 |
 | function_call | dict | 由模型生成的函数调用，包含函数名称和请求参数等。详见[`messages`](#messages)中的`function_call`。 |
 
-假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['result']`或`resp.result`均可获取`result`字段的内容。此外，使用`resp.get_result()`可以获取响应中的“主要结果”：当模型返回函数调用信息时（此时，`resp`具有`function_call`字段），`resp.get_result()`的返回结果与`resp.function_call`一致；否则，`resp.get_result()`的返回结果与`resp.result`一致，即模型给出的回复文本。
+假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['result']`或`resp.result`均可获取`result`字段的内容。此外，可以使用`resp.get_result()`获取响应中的“主要结果”：当模型返回函数调用信息时（此时，`resp`具有`function_call`字段），`resp.get_result()`的返回结果与`resp.function_call`一致；否则，`resp.get_result()`的返回结果与`resp.result`一致，即模型给出的回复文本。
 
 ## 使用示例
 

--- a/docs/api_reference/embedding.md
+++ b/docs/api_reference/embedding.md
@@ -66,7 +66,7 @@ erniebot.Embedding.create(**kwargs: Any)
 | data | list[dict] | 向量计算结果，列表中元素个数与输入的文本个数一致。列表中的元素均为dict，包含如下键值对：<br>`object`：固定为`'embedding'`； <br>`embedding`：384维的向量结果； <br>`index`：序号。 |
 | usage | dict | 输入输出token统计信息。token数量采用如下公式估算：`token数 = 汉字数 + 单词数 * 1.3`。<br>`prompt_tokens/total_tokens`：输入token数量。 |
 
-假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['data']`或`resp.data`均可获取`data`字段的内容。此外，使用`resp.get_result()`可以获取响应中的“主要结果”。对于此接口来说，`resp.get_result()`的返回结果与`resp.data`一致。
+假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['data']`或`resp.data`均可获取`data`字段的内容。此外，可以使用`resp.get_result()`获取响应中的“主要结果”。对于此接口来说，`resp.get_result()`返回一个Python list，其中顺序包含每段输入文本的向量结果。
 
 ## 使用示例
 

--- a/docs/api_reference/embedding.md
+++ b/docs/api_reference/embedding.md
@@ -66,6 +66,8 @@ erniebot.Embedding.create(**kwargs: Any)
 | data | list[dict] | 向量计算结果，列表中元素个数与输入的文本个数一致。列表中的元素均为dict，包含如下键值对：<br>`object`：固定为`'embedding'`； <br>`embedding`：384维的向量结果； <br>`index`：序号。 |
 | usage | dict | 输入输出token统计信息。token数量采用如下公式估算：`token数 = 汉字数 + 单词数 * 1.3`。<br>`prompt_tokens/total_tokens`：输入token数量。 |
 
+假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['data']`或`resp.data`均可获取`data`字段的内容。此外，使用`resp.get_result()`可以获取响应中的“主要结果”。对于此接口来说，`resp.get_result()`的返回结果与`resp.data`一致。
+
 ## 使用示例
 
 ```{.py .copy}
@@ -82,7 +84,7 @@ response = erniebot.Embedding.create(
         "2018年深圳市各区GDP"
     ])
 
-for emb_res in response.data:
+for emb_res in response.get_result():
     embedding = np.array(emb_res["embedding"])
     print(embedding)
 ```

--- a/docs/api_reference/image.md
+++ b/docs/api_reference/image.md
@@ -82,7 +82,7 @@ ernie.api_type = "yinian"
 | sub_task_error_code | int | 子任务任务错误码，`0`表示正常，`501`表示文本黄反拦截，`201`表示模型生图失败。 |
 | final_image_list | list[dict] | 子任务生成图像的列表。列表中的元素均为dict，包含如下键值对：<br>`img_url`：图片的下载地址，默认1小时后失效； <br>`height`：图片的高度； <br>`width`：图片的宽度； <br>`img_approve_conclusion`：图片机审结果，`'block'`表示输出图片违规，`'review'`表示输出图片疑似违规，`'pass'`表示输出图片未发现问题。 |
 
-假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['data']`或`resp.data`均可获取`data`字段的内容。此外，使用`resp.get_result()`可以获取响应中的“主要结果”。对于此接口来说，`resp.get_result()`的返回结果与`resp.data`一致。
+假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['data']`或`resp.data`均可获取`data`字段的内容。此外，可以使用`resp.get_result()`获取响应中的“主要结果”。对于此接口来说，`resp.get_result()`返回一个Python list，其中包含机审通过的所有图片的URL。
 
 ## 使用示例
 

--- a/docs/api_reference/image.md
+++ b/docs/api_reference/image.md
@@ -82,6 +82,8 @@ ernie.api_type = "yinian"
 | sub_task_error_code | int | 子任务任务错误码，`0`表示正常，`501`表示文本黄反拦截，`201`表示模型生图失败。 |
 | final_image_list | list[dict] | 子任务生成图像的列表。列表中的元素均为dict，包含如下键值对：<br>`img_url`：图片的下载地址，默认1小时后失效； <br>`height`：图片的高度； <br>`width`：图片的宽度； <br>`img_approve_conclusion`：图片机审结果，`'block'`表示输出图片违规，`'review'`表示输出图片疑似违规，`'pass'`表示输出图片未发现问题。 |
 
+假设`resp`为一个`erniebot.response.EBResponse`对象，字段的访问方式有2种：`resp['data']`或`resp.data`均可获取`data`字段的内容。此外，使用`resp.get_result()`可以获取响应中的“主要结果”。对于此接口来说，`resp.get_result()`的返回结果与`resp.data`一致。
+
 ## 使用示例
 
 ```{.py .copy}
@@ -92,5 +94,5 @@ erniebot.access_token = "<access-token-for-yinian>"
 
 response = erniebot.Image.create(model="ernie-vilg-v2", prompt="请帮我画一只可爱的大猫咪", width=512, height=512, version="v2", image_num=1)
 
-print(response)
+print(response.result())
 ```

--- a/docs/guides/image.md
+++ b/docs/guides/image.md
@@ -26,7 +26,7 @@ erniebot.access_token = "<access-token-for-yinian>"
 
 response = erniebot.Image.create(model="ernie-vilg-v2", prompt="请帮我画一只可爱的大猫咪", width=512, height=512, version="v2", image_num=1)
 
-print(response)
+print(response.get_result())
 
 img_url = response["data"]["sub_task_result_list"][0]["final_image_list"][0]["img_url"]
 print(img_url)

--- a/erniebot/backends.py
+++ b/erniebot/backends.py
@@ -100,21 +100,21 @@ class QianfanBackend(_BCEBackend):
             ecode = resp['error_code']
             emsg = resp['error_msg']
             if ecode == 2:
-                raise errors.ServiceUnavailableError(emsg)
+                raise errors.ServiceUnavailableError(emsg, ecode=ecode)
             elif ecode == 6:
-                raise errors.PermissionError(emsg)
+                raise errors.PermissionError(emsg, ecode=ecode)
             elif ecode in (17, 18, 19):
-                raise errors.RequestLimitError(emsg)
+                raise errors.RequestLimitError(emsg, ecode=ecode)
             elif ecode == 110:
-                raise errors.InvalidTokenError(emsg)
+                raise errors.InvalidTokenError(emsg, ecode=ecode)
             elif ecode == 111:
-                raise errors.TokenExpiredError(emsg)
+                raise errors.TokenExpiredError(emsg, ecode=ecode)
             elif ecode == 336003:
-                raise errors.InvalidParameterError(emsg)
+                raise errors.InvalidParameterError(emsg, ecode=ecode)
             elif ecode == 336100:
-                raise errors.TryAgain(emsg)
+                raise errors.TryAgain(emsg, ecode=ecode)
             else:
-                raise errors.APIError(emsg)
+                raise errors.APIError(emsg, ecode=ecode)
         else:
             return resp
 
@@ -128,17 +128,17 @@ class YinianBackend(_BCEBackend):
             ecode = resp['error_code']
             emsg = resp['error_msg']
             if ecode in (4, 13, 15, 17, 18):
-                raise errors.RequestLimitError(emsg)
+                raise errors.RequestLimitError(emsg, ecode=ecode)
             elif ecode == 6:
-                raise errors.PermissionError(emsg)
+                raise errors.PermissionError(emsg, ecode=ecode)
             elif ecode == 110:
-                raise errors.InvalidTokenError(emsg)
+                raise errors.InvalidTokenError(emsg, ecode=ecode)
             elif ecode == 111:
-                raise errors.TokenExpiredError(emsg)
+                raise errors.TokenExpiredError(emsg, ecode=ecode)
             elif ecode == 216100:
-                raise errors.InvalidParameterError(emsg)
+                raise errors.InvalidParameterError(emsg, ecode=ecode)
             else:
-                raise errors.APIError(emsg)
+                raise errors.APIError(emsg, ecode=ecode)
         else:
             return resp
 
@@ -161,21 +161,21 @@ class AIStudioBackend(EBBackend):
             ecode = resp['errorCode']
             emsg = resp['errorMsg']
             if ecode == 2:
-                raise errors.ServiceUnavailableError(emsg)
+                raise errors.ServiceUnavailableError(emsg, ecode=ecode)
             elif ecode == 6:
-                raise errors.PermissionError(emsg)
+                raise errors.PermissionError(emsg, ecode=ecode)
             elif ecode in (17, 18, 19, 40406):
-                raise errors.RequestLimitError(emsg)
+                raise errors.RequestLimitError(emsg, ecode=ecode)
             elif ecode == 110:
-                raise errors.InvalidTokenError(emsg)
+                raise errors.InvalidTokenError(emsg, ecode=ecode)
             elif ecode == 111:
-                raise errors.TokenExpiredError(emsg)
+                raise errors.TokenExpiredError(emsg, ecode=ecode)
             elif ecode == 336003:
-                raise errors.InvalidParameterError(emsg)
+                raise errors.InvalidParameterError(emsg, ecode=ecode)
             elif ecode == 336100:
-                raise errors.TryAgain(emsg)
+                raise errors.TryAgain(emsg, ecode=ecode)
             else:
-                raise errors.APIError(emsg)
+                raise errors.APIError(emsg, ecode=ecode)
         else:
             return EBResponse(resp.code, resp.result, resp.headers)
 

--- a/erniebot/config.py
+++ b/erniebot/config.py
@@ -59,7 +59,7 @@ class GlobalConfig(BaseConfig, metaclass=Singleton):
                 cfg.validate(val)
             dict_[key] = val
         if len(overrides) != 0:
-            raise ValueError(f"Unexpected keys: {list(overrides.keys())}")
+            raise KeyError(f"Unexpected keys: {list(overrides.keys())}")
         return dict_
 
 

--- a/erniebot/errors.py
+++ b/erniebot/errors.py
@@ -108,7 +108,16 @@ class TimeoutError(HTTPRequestError):
 
 class APIError(HTTPRequestError):
     """Exception that's raised when the API responds with an error code."""
-    pass
+
+    def __init__(self,
+                 message: Optional[str]=None,
+                 rcode: Optional[int]=None,
+                 rbody: Optional[str]=None,
+                 rheaders: Optional[Mapping[str, Any]]=None,
+                 ecode: Optional[int]=None) -> None:
+        super().__init__(
+            message=message, rcode=rcode, rbody=rbody, rheaders=rheaders)
+        self.ecode = ecode
 
 
 class InvalidParameterError(APIError):

--- a/erniebot/resources/__init__.py
+++ b/erniebot/resources/__init__.py
@@ -16,3 +16,7 @@ from .chat_completion import ChatCompletion
 from .chat_file import ChatFile
 from .embedding import Embedding
 from .image import Image, ImageV1, ImageV2
+
+__all__ = [
+    'ChatCompletion', 'ChatFile', 'Embedding', 'Image', 'ImageV1', 'ImageV2'
+]

--- a/erniebot/resources/abc/__init__.py
+++ b/erniebot/resources/abc/__init__.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 from .creatable import Creatable
+
+__all__ = ['Creatable']

--- a/erniebot/resources/chat_completion.py
+++ b/erniebot/resources/chat_completion.py
@@ -16,7 +16,7 @@ from typing import (Any, ClassVar, Dict, Optional, Tuple)
 
 import erniebot.errors as errors
 from erniebot.api_types import APIType
-from erniebot.response import ChatResponse
+from erniebot.response import EBResponse
 from erniebot.types import (ParamsType, HeadersType, FilesType, ResponseT)
 from erniebot.utils.misc import transform
 from .abc import Creatable
@@ -138,5 +138,25 @@ class ChatCompletion(EBResource, Creatable):
         return url, params, headers, files, stream, request_timeout
 
     def _post_process_create(self, resp: ResponseT) -> ResponseT:
-        return transform(lambda r: ChatResponse(r.code, r.body, r.headers),
-                         resp)
+        return transform(ChatResponse.from_response, resp)
+
+
+class ChatResponse(EBResponse):
+    @property
+    def is_function_response(self) -> bool:
+        return hasattr(self, 'function_call')
+
+    def get_result(self) -> Any:
+        if self.is_function_response:
+            return self.function_call
+        else:
+            return self.result
+
+    def to_message(self) -> Dict[str, Any]:
+        message: Dict[str, Any] = {'role': 'assistant'}
+        if self.is_function_response:
+            message['content'] = None
+            message['function_call'] = self.function_call
+        else:
+            message['content'] = self.result
+        return message

--- a/erniebot/resources/chat_completion.py
+++ b/erniebot/resources/chat_completion.py
@@ -16,7 +16,9 @@ from typing import (Any, ClassVar, Dict, Optional, Tuple)
 
 import erniebot.errors as errors
 from erniebot.api_types import APIType
+from erniebot.response import ChatResponse
 from erniebot.types import (ParamsType, HeadersType, FilesType, ResponseT)
+from erniebot.utils.misc import transform
 from .abc import Creatable
 from .resource import EBResource
 
@@ -136,4 +138,5 @@ class ChatCompletion(EBResource, Creatable):
         return url, params, headers, files, stream, request_timeout
 
     def _post_process_create(self, resp: ResponseT) -> ResponseT:
-        return resp
+        return transform(lambda r: ChatResponse(r.code, r.body, r.headers),
+                         resp)

--- a/erniebot/resources/chat_file.py
+++ b/erniebot/resources/chat_file.py
@@ -16,7 +16,9 @@ from typing import (Any, ClassVar, Dict, Optional, Tuple)
 
 import erniebot.errors as errors
 from erniebot.api_types import APIType
+from erniebot.response import ChatResponse
 from erniebot.types import (ParamsType, HeadersType, FilesType, ResponseT)
+from erniebot.utils.misc import transform
 from .abc import Creatable
 from .resource import EBResource
 
@@ -74,4 +76,5 @@ class ChatFile(EBResource, Creatable):
         return url, params, headers, files, stream, request_timeout
 
     def _post_process_create(self, resp: ResponseT) -> ResponseT:
-        return resp
+        return transform(lambda r: ChatResponse(r.code, r.body, r.headers),
+                         resp)

--- a/erniebot/resources/chat_file.py
+++ b/erniebot/resources/chat_file.py
@@ -16,10 +16,10 @@ from typing import (Any, ClassVar, Dict, Optional, Tuple)
 
 import erniebot.errors as errors
 from erniebot.api_types import APIType
-from erniebot.response import ChatResponse
 from erniebot.types import (ParamsType, HeadersType, FilesType, ResponseT)
 from erniebot.utils.misc import transform
 from .abc import Creatable
+from .chat_completion import ChatResponse
 from .resource import EBResource
 
 
@@ -76,5 +76,4 @@ class ChatFile(EBResource, Creatable):
         return url, params, headers, files, stream, request_timeout
 
     def _post_process_create(self, resp: ResponseT) -> ResponseT:
-        return transform(lambda r: ChatResponse(r.code, r.body, r.headers),
-                         resp)
+        return transform(ChatResponse.from_response, resp)

--- a/erniebot/resources/embedding.py
+++ b/erniebot/resources/embedding.py
@@ -16,7 +16,9 @@ from typing import (Any, ClassVar, Dict, Optional, Tuple)
 
 import erniebot.errors as errors
 from erniebot.api_types import APIType
+from erniebot.response import EBResponse
 from erniebot.types import (ParamsType, HeadersType, FilesType, ResponseT)
+from erniebot.utils.misc import transform
 from .abc import Creatable
 from .resource import EBResource
 
@@ -106,4 +108,8 @@ class Embedding(EBResource, Creatable):
         return url, params, headers, files, stream, request_timeout
 
     def _post_process_create(self, resp: ResponseT) -> ResponseT:
-        return resp
+        def _process(resp: EBResponse) -> EBResponse:
+            resp.set_result_key('data')
+            return resp
+
+        return transform(_process, resp)

--- a/erniebot/resources/embedding.py
+++ b/erniebot/resources/embedding.py
@@ -108,8 +108,12 @@ class Embedding(EBResource, Creatable):
         return url, params, headers, files, stream, request_timeout
 
     def _post_process_create(self, resp: ResponseT) -> ResponseT:
-        def _process(resp: EBResponse) -> EBResponse:
-            resp.set_result_key('data')
-            return resp
+        return transform(EmbeddingResponse.from_response, resp)
 
-        return transform(_process, resp)
+
+class EmbeddingResponse(EBResponse):
+    def get_result(self) -> Any:
+        embeddings = []
+        for res in self.data:
+            embeddings.append(res['embedding'])
+        return embeddings

--- a/erniebot/resources/image.py
+++ b/erniebot/resources/image.py
@@ -202,7 +202,6 @@ class ImageV1(_Image):
         return url, params, headers
 
     def _post_process(self, resp_f: EBResponse) -> EBResponse:
-        resp_f.set_result_key('data')
         return resp_f
 
     @staticmethod
@@ -306,8 +305,7 @@ class ImageV2(_Image):
         return url, params, headers
 
     def _post_process(self, resp_f: EBResponse) -> EBResponse:
-        resp_f.set_result_key('data')
-        return resp_f
+        return ImageV2Response.from_response(resp_f)
 
     @staticmethod
     def _check_status(resp: EBResponse) -> bool:
@@ -317,4 +315,16 @@ class ImageV2(_Image):
         return status == 'SUCCESS'
 
 
+class ImageV2Response(EBResponse):
+    def get_result(self) -> Any:
+        image_urls = []
+        for task_item in self.data['sub_task_result_list']:
+            for image_item in task_item['final_image_list']:
+                review_conclusion = image_item['img_approve_conclusion']
+                if review_conclusion == 'pass':
+                    image_urls.append(image_item['img_url'])
+        return image_urls
+
+
 Image: TypeAlias = ImageV2
+ImageResponse: TypeAlias = ImageV2Response

--- a/erniebot/resources/image.py
+++ b/erniebot/resources/image.py
@@ -64,6 +64,8 @@ class _Image(EBResource):
             # XXX: Reuse `request_timeout`. Should we implement finer-grained control?
             request_timeout=request_timeout)
 
+        resp_f = self._post_process(resp_f)
+
         return resp_f
 
     async def acreate_resource(self, **create_kwargs: Any) -> EBResponse:
@@ -89,6 +91,8 @@ class _Image(EBResource):
             # XXX: Reuse `request_timeout`. Should we implement finer-grained control?
             request_timeout=request_timeout)
 
+        resp_f = self._post_process(resp_f)
+
         return resp_f
 
     def _prepare_paint(self,
@@ -103,6 +107,9 @@ class _Image(EBResource):
                                                           Optional[ParamsType],
                                                           Optional[HeadersType],
                                                           ]:
+        raise NotImplementedError
+
+    def _post_process(self, resp_f: EBResponse) -> EBResponse:
         raise NotImplementedError
 
     @staticmethod
@@ -193,6 +200,10 @@ class ImageV1(_Image):
         headers = {'Accept': 'application/json'}
 
         return url, params, headers
+
+    def _post_process(self, resp_f: EBResponse) -> EBResponse:
+        resp_f.set_result_key('data')
+        return resp_f
 
     @staticmethod
     def _check_status(resp: EBResponse) -> bool:
@@ -293,6 +304,10 @@ class ImageV2(_Image):
         headers = {'Accept': 'application/json'}
 
         return url, params, headers
+
+    def _post_process(self, resp_f: EBResponse) -> EBResponse:
+        resp_f.set_result_key('data')
+        return resp_f
 
     @staticmethod
     def _check_status(resp: EBResponse) -> bool:

--- a/erniebot/utils/misc.py
+++ b/erniebot/utils/misc.py
@@ -14,8 +14,9 @@
 
 import threading
 from typing import (ClassVar)
+from collections.abc import AsyncIterator, Iterator
 
-__all__ = ['Constant', 'Singleton']
+__all__ = ['Constant', 'Singleton', 'transform']
 
 
 class Constant(object):
@@ -40,3 +41,12 @@ class Singleton(type):
                 if cls not in cls._insts:
                     cls._insts[cls] = super().__call__(*args, **kwargs)
         return cls._insts[cls]
+
+
+def transform(func, data):
+    if isinstance(data, Iterator):
+        return (func(d) for d in data)
+    elif isinstance(data, AsyncIterator):
+        return (func(d) async for d in data)
+    else:
+        return func(data)

--- a/tests/chat_completion.py
+++ b/tests/chat_completion.py
@@ -1,5 +1,8 @@
+import sys
+
 import erniebot
 from erniebot.utils import logger
+
 logger.set_level("WARNING")
 
 
@@ -18,7 +21,7 @@ def test_chat_completion(model="ernie-bot"):
             "content": "我在深圳，周末可以去哪里玩？"
         }],
         stream=False)
-    print(response)
+    print(response.get_result())
 
 
 def test_chat_completion_stream_mode(model="ernie-bot"):
@@ -38,7 +41,9 @@ def test_chat_completion_stream_mode(model="ernie-bot"):
         stream=True)
 
     for item in response:
-        print(item)
+        sys.stdout.write(item.get_result())
+        sys.stdout.flush()
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/tests/chat_completion_aio.py
+++ b/tests/chat_completion_aio.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import asyncio
+import sys
 
 import erniebot
 from erniebot.utils import logger
@@ -23,7 +24,7 @@ async def acreate_chat_completion(model):
             'content': "我在深圳，周末可以去哪里玩？"
         }],
         stream=False)
-    print(resp)
+    print(resp.get_result())
 
 
 async def acreate_chat_completion_stream(model):
@@ -43,7 +44,9 @@ async def acreate_chat_completion_stream(model):
         stream=True)
 
     async for item in resp:
-        print(item)
+        sys.stdout.write(item.get_result())
+        sys.stdout.flush()
+    sys.stdout.write("\n")
 
 
 async def test_aio(target, args):

--- a/tests/chat_completion_mt.py
+++ b/tests/chat_completion_mt.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 import threading
 
 import erniebot
@@ -23,7 +24,7 @@ def create_chat_completion(model):
             'content': "我在深圳，周末可以去哪里玩？"
         }],
         stream=False)
-    print(resp)
+    print(resp.get_result())
 
 
 def create_chat_completion_stream(model):
@@ -43,7 +44,9 @@ def create_chat_completion_stream(model):
         stream=True)
 
     for item in resp:
-        print(item)
+        sys.stdout.write(item.get_result())
+        sys.stdout.flush()
+    sys.stdout.write("\n")
 
 
 def test_mt(target, args):

--- a/tests/chat_file.py
+++ b/tests/chat_file.py
@@ -22,4 +22,4 @@ if __name__ == '__main__':
             "content": "应对未来的技术挑战，AI框架有哪些独特的技术特色？"
         }],
         stream=False)
-    print(response)
+    print(response.get_result())

--- a/tests/embedding.py
+++ b/tests/embedding.py
@@ -8,5 +8,4 @@ if __name__ == '__main__':
             "我是百度公司开发的人工智能语言模型，我的中文名是文心一言，英文名是ERNIE-Bot，可以协助您完成范围广泛的任务并提供有关各种主题的信息，比如回答问题，提供定义和解释及建议。如果您有任何问题，请随时向我提问。",
             "2018年深圳市各区GDP"
         ])
-    print(response)
-    print(type(response))
+    print(response.get_result())

--- a/tests/function_calling.py
+++ b/tests/function_calling.py
@@ -67,7 +67,7 @@ def test_function_calling(model="ernie-bot"):
             },
         }, ],
         stream=False)
-    print(response)
+    print(response.get_result())
 
 
 if __name__ == "__main__":

--- a/tests/function_calling.py
+++ b/tests/function_calling.py
@@ -7,34 +7,10 @@ from erniebot.utils import logger
 def test_function_calling(model="ernie-bot"):
     response = erniebot.ChatCompletion.create(
         model=model,
-        messages=[
-            {
-                "role": "user",
-                "content": "深圳市今天气温如何？",
-            },
-            {
-                "role": "assistant",
-                "content": None,
-                "function_call": {
-                    "name": "get_current_temperature",
-                    "arguments": json.dumps(
-                        {
-                            "location": "深圳市",
-                            "unit": "摄氏度",
-                        },
-                        ensure_ascii=False),
-                },
-            },
-            {
-                "role": "function",
-                "name": "get_current_temperature",
-                "content": json.dumps(
-                    {
-                        "temperature": 25,
-                        "type": "摄氏度",
-                    }, ensure_ascii=False),
-            },
-        ],
+        messages=[{
+            "role": "user",
+            "content": "深圳市今天气温多少摄氏度？",
+        }, ],
         functions=[{
             "name": "get_current_temperature",
             "description": "获取指定城市的气温",
@@ -74,4 +50,4 @@ if __name__ == "__main__":
     logger.set_level("WARNING")
     erniebot.api_type = "qianfan"
 
-    test_function_calling(model="ernie-bot-turbo")
+    test_function_calling(model="ernie-bot")

--- a/tests/image.py
+++ b/tests/image.py
@@ -12,4 +12,4 @@ if __name__ == "__main__":
         height=512,
         version='v2',
         image_num=1)
-    print(response)
+    print(response.get_result())


### PR DESCRIPTION
- 添加`EBResponse.get_result`方法，支持从响应中取出“关键字段”。取名为`result`而非`message`是为了防止用户混淆，因为`message`一词已经在`ChatCompletion`的输入参数中被占用。更新了相关文档和测试。
- 对于`ChatCompletion`，封装了特定的响应类`ChatResponse`，并加入两个功能：支持使用`to_message`方法一键从响应中生成可用于下一轮对话输入的`message`（代替用户手动构造）以及通过`is_function_response`判断响应是否对应函数调用（代替用户通过`hasattr`或者`in`判断字段是否存在）。
- `APIError`新增`ecode`字段，可供中高阶开发者获取服务器返回的原始错误码。