### PR TITLE
[Feat] Add `Agent.launch_gradio_demo`

### DIFF
--- a/erniebot-agent/erniebot_agent/agents/base.py
+++ b/erniebot-agent/erniebot_agent/agents/base.py
@@ -78,8 +78,14 @@ class Agent(BaseAgent):
         self.memory.clear_chat_history()
 
     def launch_gradio_demo(self, **launch_kwargs: Any):
-        # TODO: Optional dependencies management
-        import gradio as gr
+        # TODO: Unified optional dependencies management
+        try:
+            import gradio as gr
+        except ImportError:
+            raise ImportError(
+                "Could not import gradio, which is required for `launch_gradio_demo()`."
+                " Please run `pip install erniebot-agent[gradio]` to install the optional dependencies."
+            ) from None
 
         raw_messages = []
 

--- a/erniebot-agent/erniebot_agent/extensions/langchain/chat_models/erniebot.py
+++ b/erniebot-agent/erniebot_agent/extensions/langchain/chat_models/erniebot.py
@@ -143,7 +143,7 @@ class ErnieBotChat(BaseChatModel):
             values["client"] = erniebot.ChatCompletion
         except ImportError:
             raise ImportError(
-                "Could not import erniebot python package. " "Please install it with `pip install erniebot`."
+                "Could not import erniebot python package. Please install it with `pip install erniebot`."
             )
         return values
 
@@ -268,7 +268,7 @@ class ErnieBotChat(BaseChatModel):
         for msg in messages:
             if isinstance(msg, SystemMessage):
                 logger.warning(
-                    "Ignoring system messages " "since they are currently not supported for ERNIE Bot."
+                    "Ignoring system messages since they are currently not supported for ERNIE Bot."
                 )
                 continue
             eb_msg = self._convert_message_to_dict(msg)

--- a/erniebot-agent/erniebot_agent/extensions/langchain/embeddings/ernie.py
+++ b/erniebot-agent/erniebot_agent/extensions/langchain/embeddings/ernie.py
@@ -76,7 +76,7 @@ class ErnieEmbeddings(BaseModel, Embeddings):
             values["client"] = erniebot.Embedding
         except ImportError:
             raise ImportError(
-                "Could not import erniebot python package. " "Please install it with `pip install erniebot`."
+                "Could not import erniebot python package. Please install it with `pip install erniebot`."
             )
         return values
 

--- a/erniebot-agent/erniebot_agent/extensions/langchain/llms/erniebot.py
+++ b/erniebot-agent/erniebot_agent/extensions/langchain/llms/erniebot.py
@@ -104,7 +104,7 @@ class ErnieBot(LLM):
             values["client"] = erniebot.ChatCompletion
         except ImportError:
             raise ImportError(
-                "Could not import erniebot python package. " "Please install it with `pip install erniebot`."
+                "Could not import erniebot python package. Please install it with `pip install erniebot`."
             )
         return values
 

--- a/erniebot-agent/setup.cfg
+++ b/erniebot-agent/setup.cfg
@@ -25,7 +25,8 @@ console_scripts =
     erniebot_agent = erniebot_agent.__main__:console_entry
 
 [options.extras_require]
-docs = file: doc-requirements.txt
+gradio = 
+    gradio >= 3.48
 
 [sdist]
 dist_dir = output/dist


### PR DESCRIPTION
添加`Agent.launch_gradio_demo` API，可用于本地调试agent。

目前仅实现初步版本，部分遗留问题如下：
1. 当处理事件的过程中（例如调用`_chat`函数时）发生错误时，可能出现错误的历史记录，导致gradio显示异常（需要用户手动点击Clear按钮或刷新网页）。
2. `Agent.launch_gradio_demo`不支持任何形式的并发，所有的操作都应该是synchronous、blocking的，但gradio是并发的，因此在部分情况下可能出现意料之外的结果。例如：两个用户在不同浏览器中同时操作，或是用户在agent run尚未完成时点击Clear按钮。目前仅实现了agent run进行时锁定输入文本框和Submit按钮。
3. 缺少docstring。