### PR TITLE
[Bug fix] Fix `RemoteTool` missing `tool_name`

### DIFF
--- a/erniebot-agent/erniebot_agent/tools/base.py
+++ b/erniebot-agent/erniebot_agent/tools/base.py
@@ -107,12 +107,6 @@ class RemoteTool(BaseTool):
         return self.tool_view.function_call_schema()
 
 
-headers = {
-    "Authorization": "token 052cf34e334a5c816f501495b102a5b9819cc5ff",
-    "Content-Type": "application/json",
-}
-
-
 @dataclass
 class RemoteToolkit:
     """RemoteToolkit can be converted by openapi.yaml and endpoint"""
@@ -235,6 +229,7 @@ class RemoteToolkit:
             file_path = os.path.join(temp_dir, "openapi.yaml")
             with open(file_path, "w+", encoding="utf-8") as f:
                 f.write(file_content)
+            print(file_path)
 
             toolkit = RemoteToolkit.from_openapi_file(file_path, access_token=access_token)
             for server in toolkit.servers:

--- a/erniebot-agent/erniebot_agent/tools/base.py
+++ b/erniebot-agent/erniebot_agent/tools/base.py
@@ -85,6 +85,7 @@ class Tool(BaseTool, ABC):
 class RemoteTool(BaseTool):
     def __init__(self, tool_view: RemoteToolView, server_url: str, headers: dict) -> None:
         self.tool_view = tool_view
+        self.tool_name = tool_view.name
         self.server_url = server_url
         self.headers = headers
 
@@ -104,6 +105,12 @@ class RemoteTool(BaseTool):
 
     def function_call_schema(self) -> dict:
         return self.tool_view.function_call_schema()
+
+
+headers = {
+    "Authorization": "token 052cf34e334a5c816f501495b102a5b9819cc5ff",
+    "Content-Type": "application/json",
+}
 
 
 @dataclass


### PR DESCRIPTION
Since `RemoteTool` has no `tool_name` attribute, it cannot be used by the `ToolManger` and the `Agent` class