### PR TITLE
Add `tool_name_prefix` to `RemoteTool`

### DIFF
--- a/erniebot-agent/erniebot_agent/tools/base.py
+++ b/erniebot-agent/erniebot_agent/tools/base.py
@@ -150,12 +150,18 @@ class RemoteTool(BaseTool):
         headers: dict,
         version: str,
         examples: Optional[List[Message]] = None,
+        tool_name_prefix: Optional[str] = None,
     ) -> None:
         self.tool_view = tool_view
         self.server_url = server_url
         self.headers = headers
         self.version = version
         self.examples = examples
+        self.tool_name_prefix = tool_name_prefix
+        # If `tool_name_prefix`` is provided, we prepend `tool_name_prefix`` to the `name` field of all tools
+        if tool_name_prefix is not None:
+            self.tool_view.name = f"{self.tool_name_prefix}/{self.tool_view.name}"
+
         self.file_manager = FileManager()
 
     def __str__(self) -> str:
@@ -182,7 +188,7 @@ class RemoteTool(BaseTool):
         }
         if self.tool_view.method == "get":
             requests_inputs["params"] = tool_arguments
-        if self.tool_view.parameters_content_type == "application/json":
+        elif self.tool_view.parameters_content_type == "application/json":
             requests_inputs["json"] = tool_arguments
         elif self.tool_view.parameters_content_type == "application/x-www-form-urlencoded":
             requests_inputs["data"] = tool_arguments
@@ -201,7 +207,10 @@ class RemoteTool(BaseTool):
             raise ValueError(f"method<{self.tool_view.method}> is invalid")
 
         if response.status_code != 200:
-            raise ValueError(f"the resource is invalid, the error message is: {response.text}")
+            raise ValueError(
+                f"The resource requested by `{self.tool_name}` returned"
+                f"{response.status_code}: {response.text}"
+            )
 
         # parse the file from response
         file_names = []
@@ -255,7 +264,11 @@ class RemoteToolkit:
     headers: dict
     examples: List[Message] = field(default_factory=list)
 
-    def __getitem__(self, tool_name: str):
+    @property
+    def tool_name_prefix(self) -> str:
+        return f"{self.info.title}/{self.info.version}"
+
+    def __getitem__(self, tool_name: str) -> RemoteTool:
         return self.get_tool(tool_name)
 
     def get_tools(self) -> List[RemoteTool]:
@@ -266,6 +279,7 @@ class RemoteToolkit:
                 self.headers,
                 self.info.version,
                 examples=self.get_examples_by_name(path.name),
+                tool_name_prefix=self.tool_name_prefix,
             )
             for path in self.paths
         ]
@@ -306,6 +320,11 @@ class RemoteToolkit:
             tool_names = [name for name in tool_names if name]
 
             if tool_name in tool_names:
+                # 3. prepend `tool_name_prefix` to all tool names in examples
+                for example in examples:
+                    if isinstance(example, AIMessage) and example.function_call is not None:
+                        original_tool_name = example.function_call["name"]
+                        example.function_call["name"] = f"{self.tool_name_prefix}/{original_tool_name}"
                 final_exampels.extend(examples)
 
         return final_exampels
@@ -319,6 +338,7 @@ class RemoteToolkit:
             self.headers,
             self.info.version,
             examples=self.get_examples_by_name(tool_name),
+            tool_name_prefix=self.tool_name_prefix,
         )
 
     def to_openapi_dict(self) -> dict:

--- a/erniebot-agent/erniebot_agent/tools/base.py
+++ b/erniebot-agent/erniebot_agent/tools/base.py
@@ -250,9 +250,7 @@ class RemoteTool(BaseTool):
             examples = []
             # prepend `tool_name_prefix` to all tool names in examples
             for example in self.examples:
-                print(example)
                 if isinstance(example, AIMessage) and example.function_call is not None:
-                    print("here")
                     original_tool_name = example.function_call["name"]
                     example.function_call["name"] = f"{self.tool_name_prefix}/{original_tool_name}"
                 examples.append(example.to_dict())

--- a/erniebot-agent/erniebot_agent/tools/schema.py
+++ b/erniebot-agent/erniebot_agent/tools/schema.py
@@ -419,8 +419,6 @@ class RemoteToolView:
         inputs = {
             "name": self.name,
             "description": self.description,
-            # TODO(wj-Mcat): read examples from openapi.yaml
-            # "examples": [example.to_dict() for example in self.examples],
         }
         if self.parameters is not None:
             inputs["parameters"] = self.parameters.function_call_schema()  # type: ignore

--- a/erniebot-agent/tests/unit_tests/tools/test_file_in_tool.py
+++ b/erniebot-agent/tests/unit_tests/tools/test_file_in_tool.py
@@ -146,8 +146,10 @@ class TestToolWithFile(unittest.TestCase):
 
             toolkit = RemoteToolkit.from_openapi_file(openapi_file)
             tool = toolkit.get_tool("getFile")
-            # Check if tool_name_prefix in RemoteToolkit is properly prepended
-            self.assertEqual(tool.tool_name, "TestRemoteTool/v1/getFile")
+            # tool.tool_name should be original tool name
+            self.assertEqual(tool.tool_name, "getFile")
+            # tool_name from function_call_schema have tool_name_prefix prepended
+            self.assertEqual(tool.function_call_schema()["name"], "TestRemoteTool/v1/getFile")
             file_manager = FileManager()
             input_file = asyncio.run(file_manager.create_file_from_path(self.file_path))
             result = asyncio.run(tool(file=input_file.id))

--- a/erniebot-agent/tests/unit_tests/tools/test_file_in_tool.py
+++ b/erniebot-agent/tests/unit_tests/tools/test_file_in_tool.py
@@ -29,7 +29,7 @@ from fastapi.responses import FileResponse
 
 PYYAML_CONTENT = """openapi: 3.0.1
 info:
-    title: 测试 Remote Tool
+    title: TestRemoteTool
     description: 个性化的英文单词本，可以增加、删除和浏览单词本中的单词，背单词时从已有单词本中随机抽取单词生成句子或者段落。
     version: "v1"
 servers:
@@ -146,6 +146,8 @@ class TestToolWithFile(unittest.TestCase):
 
             toolkit = RemoteToolkit.from_openapi_file(openapi_file)
             tool = toolkit.get_tool("getFile")
+            # Check if tool_name_prefix in RemoteToolkit is properly prepended
+            self.assertEqual(tool.tool_name, "TestRemoteTool/v1/getFile")
             file_manager = FileManager()
             input_file = asyncio.run(file_manager.create_file_from_path(self.file_path))
             result = asyncio.run(tool(file=input_file.id))
@@ -154,4 +156,4 @@ class TestToolWithFile(unittest.TestCase):
 
             file = file_manager.look_up_file_by_id(file_id=file_id)
             content = asyncio.run(file.read_contents())
-            self.assertEquals(content.decode("utf-8"), self.content)
+            self.assertEqual(content.decode("utf-8"), self.content)

--- a/erniebot-agent/tests/unit_tests/tools/test_schema.py
+++ b/erniebot-agent/tests/unit_tests/tools/test_schema.py
@@ -29,6 +29,7 @@ from pydantic import Field
 
 class TestToolSchema(unittest.TestCase):
     openapi_file = "./tests/fixtures/openapi.yaml"
+    examples_file = "./tests/fixtures/examples.yaml"
 
     def test_plugin_schema(self):
         schema = RemoteToolkit.from_openapi_file(self.openapi_file)
@@ -54,6 +55,22 @@ class TestToolSchema(unittest.TestCase):
         self.assertEqual(function_call_schemas[0]["responses"]["required"], ["wordbook"])
         self.assertEqual(function_call_schemas[0]["responses"]["properties"]["wordbook"]["type"], "array")
         self.assertEqual(function_call_schemas[3]["name"], "单词本/v1/deleteWord")
+
+    def test_function_call_schemas_with_examples(self):
+        toolkit = RemoteToolkit.from_openapi_file(self.openapi_file)
+        toolkit.examples = toolkit.load_examples_yaml(self.examples_file)
+        function_call_schemas = [tool.function_call_schema() for tool in toolkit.get_tools()]
+        self.assertEqual(len(function_call_schemas), 4)
+        self.assertEqual(function_call_schemas[0]["name"], "单词本/v1/getWordbook")
+        self.assertEqual(
+            function_call_schemas[0]["examples"][1]["function_call"]["name"], "单词本/v1/getWordbook"
+        )
+        self.assertEqual(function_call_schemas[0]["responses"]["required"], ["wordbook"])
+        self.assertEqual(function_call_schemas[0]["responses"]["properties"]["wordbook"]["type"], "array")
+        self.assertEqual(function_call_schemas[3]["name"], "单词本/v1/deleteWord")
+        self.assertEqual(
+            function_call_schemas[3]["examples"][1]["function_call"]["name"], "单词本/v1/deleteWord"
+        )
 
     def test_get_typing_list_type(self):
         result = get_typing_list_type(List[int])
@@ -174,8 +191,8 @@ class TestToolSchema(unittest.TestCase):
         self.assertTrue(is_optional_type(Optional[ToolParameterView]))
 
     def test_load_examples(self):
-        toolkit = RemoteToolkit.from_openapi_file("./tests/fixtures/openapi.yaml")
-        toolkit.examples = toolkit.load_examples_yaml("./tests/fixtures/examples.yaml")
+        toolkit = RemoteToolkit.from_openapi_file(self.openapi_file)
+        toolkit.examples = toolkit.load_examples_yaml(self.examples_file)
         self.assertEqual(len(toolkit.examples), 12)
 
         # add_word examples
@@ -183,5 +200,6 @@ class TestToolSchema(unittest.TestCase):
 
         self.assertEqual(len(examples), 2)
         self.assertEqual(examples[0].content, "展示单词列表")
-        self.assertEqual(examples[1].function_call["name"], "单词本/v1/getWordbook")
+        # Note: example still have the original function name without function_call_schema() call
+        self.assertEqual(examples[1].function_call["name"], "getWordbook")
         self.assertEqual(examples[1].function_call["thoughts"], "这是一个展示单词本的需求")

--- a/erniebot-agent/tests/unit_tests/tools/test_schema.py
+++ b/erniebot-agent/tests/unit_tests/tools/test_schema.py
@@ -50,10 +50,10 @@ class TestToolSchema(unittest.TestCase):
         function_call_schemas = [tool.function_call_schema() for tool in toolkit.get_tools()]
         self.assertEqual(len(function_call_schemas), 4)
 
-        self.assertEqual(function_call_schemas[0]["name"], "getWordbook")
+        self.assertEqual(function_call_schemas[0]["name"], "单词本/v1/getWordbook")
         self.assertEqual(function_call_schemas[0]["responses"]["required"], ["wordbook"])
         self.assertEqual(function_call_schemas[0]["responses"]["properties"]["wordbook"]["type"], "array")
-        self.assertEqual(function_call_schemas[3]["name"], "deleteWord")
+        self.assertEqual(function_call_schemas[3]["name"], "单词本/v1/deleteWord")
 
     def test_get_typing_list_type(self):
         result = get_typing_list_type(List[int])
@@ -183,5 +183,5 @@ class TestToolSchema(unittest.TestCase):
 
         self.assertEqual(len(examples), 2)
         self.assertEqual(examples[0].content, "展示单词列表")
-        self.assertEqual(examples[1].function_call["name"], "getWordbook")
+        self.assertEqual(examples[1].function_call["name"], "单词本/v1/getWordbook")
         self.assertEqual(examples[1].function_call["thoughts"], "这是一个展示单词本的需求")


### PR DESCRIPTION
Adding `tool_name_prefix` since:
1. tools can potentially have duplicate names
2. adding tool name prefix with the toolkit title and version allow us to trace back to the toolkit