### PR TITLE
[Bug fix] Fix `tool_name_prefix` in `get_tool` and `get_tools`

### DIFF
--- a/erniebot-agent/erniebot_agent/tools/base.py
+++ b/erniebot-agent/erniebot_agent/tools/base.py
@@ -158,6 +158,9 @@ class RemoteTool(BaseTool):
         self.version = version
         self.examples = examples
         self.tool_name_prefix = tool_name_prefix
+        # If `tool_name_prefix`` is provided, we prepend `tool_name_prefix`` to the `name` field of all tools
+        if tool_name_prefix is not None:
+            self.tool_view.name = f"{self.tool_name_prefix}/{self.tool_view.name}"
 
         self.file_manager = FileManager()
 
@@ -242,19 +245,8 @@ class RemoteTool(BaseTool):
 
     def function_call_schema(self) -> dict:
         schema = self.tool_view.function_call_schema()
-        # If `tool_name_prefix`` is provided, we prepend `tool_name_prefix`` to the `name` field of all tools
-        if self.tool_name_prefix is not None:
-            original_name = schema["name"]
-            schema["name"] = f"{self.tool_name_prefix}/{original_name}"
         if self.examples is not None:
-            examples = []
-            # prepend `tool_name_prefix` to all tool names in examples
-            for example in self.examples:
-                if isinstance(example, AIMessage) and example.function_call is not None:
-                    original_tool_name = example.function_call["name"]
-                    example.function_call["name"] = f"{self.tool_name_prefix}/{original_tool_name}"
-                examples.append(example.to_dict())
-            schema["examples"] = examples
+            schema["examples"] = [example.to_dict() for example in self.examples]
 
         return schema or {}
 
@@ -328,6 +320,11 @@ class RemoteToolkit:
             tool_names = [name for name in tool_names if name]
 
             if tool_name in tool_names:
+                # 3. prepend `tool_name_prefix` to all tool names in examples
+                for example in examples:
+                    if isinstance(example, AIMessage) and example.function_call is not None:
+                        original_tool_name = example.function_call["name"]
+                        example.function_call["name"] = f"{self.tool_name_prefix}/{original_tool_name}"
                 final_exampels.extend(examples)
 
         return final_exampels

--- a/erniebot-agent/erniebot_agent/tools/tool_manager.py
+++ b/erniebot-agent/erniebot_agent/tools/tool_manager.py
@@ -36,6 +36,7 @@ class ToolManager(object):
         return self.get_tool(tool_name)
 
     def add_tool(self, tool: Tool) -> None:
+        print(f"adding {tool.tool_name}")
         tool_name = tool.tool_name
         if tool_name in self._tools:
             raise RuntimeError(f"Name {repr(tool_name)} is already registered.")

--- a/erniebot-agent/tests/unit_tests/tools/test_file_in_tool.py
+++ b/erniebot-agent/tests/unit_tests/tools/test_file_in_tool.py
@@ -146,10 +146,8 @@ class TestToolWithFile(unittest.TestCase):
 
             toolkit = RemoteToolkit.from_openapi_file(openapi_file)
             tool = toolkit.get_tool("getFile")
-            # tool.tool_name should be original tool name
-            self.assertEqual(tool.tool_name, "getFile")
-            # tool_name from function_call_schema have tool_name_prefix prepended
-            self.assertEqual(tool.function_call_schema()["name"], "TestRemoteTool/v1/getFile")
+            # tool.tool_name should have `tool_name_prefix`` prepended
+            self.assertEqual(tool.tool_name, "TestRemoteTool/v1/getFile")
             file_manager = FileManager()
             input_file = asyncio.run(file_manager.create_file_from_path(self.file_path))
             result = asyncio.run(tool(file=input_file.id))

--- a/erniebot-agent/tests/unit_tests/tools/test_schema.py
+++ b/erniebot-agent/tests/unit_tests/tools/test_schema.py
@@ -200,6 +200,6 @@ class TestToolSchema(unittest.TestCase):
 
         self.assertEqual(len(examples), 2)
         self.assertEqual(examples[0].content, "展示单词列表")
-        # Note: example still have the original function name without function_call_schema() call
-        self.assertEqual(examples[1].function_call["name"], "getWordbook")
+        # function_call name in examples should have `tool_name_prefix` prepended
+        self.assertEqual(examples[1].function_call["name"], "单词本/v1/getWordbook")
         self.assertEqual(examples[1].function_call["thoughts"], "这是一个展示单词本的需求")


### PR DESCRIPTION
Previously the logic of prepending `tool_name_prefix` only occurs after calling `function_call_schema()`, which is too late. Moving the logic to right after constructing `RemoteTool`