### PR TITLE
[Agent][Fix] Rely on interfaces rather than implementations

### DIFF
--- a/erniebot-agent/erniebot_agent/agents/base.py
+++ b/erniebot-agent/erniebot_agent/agents/base.py
@@ -233,7 +233,10 @@ class Agent(BaseAgent):
         # or can we have the tools introspect about this?
         input_files = await self._sniff_and_extract_files_from_args(parsed_tool_args, tool, "input")
         tool_ret = await tool(**parsed_tool_args)
-        output_files = await self._sniff_and_extract_files_from_args(tool_ret, tool, "output")
+        if isinstance(tool_ret, dict):
+            output_files = await self._sniff_and_extract_files_from_args(tool_ret, tool, "output")
+        else:
+            output_files = []
         tool_ret_json = json.dumps(tool_ret, ensure_ascii=False)
         return ToolResponse(json=tool_ret_json, files=input_files + output_files)
 

--- a/erniebot-agent/erniebot_agent/agents/base.py
+++ b/erniebot-agent/erniebot_agent/agents/base.py
@@ -32,15 +32,12 @@ from erniebot_agent.file_io.file_manager import FileManager
 from erniebot_agent.file_io.protocol import is_local_file_id, is_remote_file_id
 from erniebot_agent.memory.base import Memory
 from erniebot_agent.messages import Message, SystemMessage
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 from erniebot_agent.tools.tool_manager import ToolManager
 from erniebot_agent.utils.logging import logger
 
 
 class BaseAgent(metaclass=abc.ABCMeta):
-    llm: ChatModel
-    memory: Memory
-
     @abc.abstractmethod
     async def async_run(self, prompt: str, files: Optional[List[File]] = None) -> AgentResponse:
         raise NotImplementedError
@@ -50,7 +47,7 @@ class Agent(BaseAgent):
     def __init__(
         self,
         llm: ChatModel,
-        tools: Union[ToolManager, List[Tool]],
+        tools: Union[ToolManager, List[BaseTool]],
         memory: Memory,
         *,
         system_message: Optional[SystemMessage] = None,
@@ -80,16 +77,20 @@ class Agent(BaseAgent):
             file_manager = file_io.get_file_manager()
         self._file_manager = file_manager
 
+    @property
+    def tools(self) -> List[BaseTool]:
+        return self._tool_manager.get_tools()
+
     async def async_run(self, prompt: str, files: Optional[List[File]] = None) -> AgentResponse:
         await self._callback_manager.on_run_start(agent=self, prompt=prompt)
         agent_resp = await self._async_run(prompt, files)
         await self._callback_manager.on_run_end(agent=self, response=agent_resp)
         return agent_resp
 
-    def load_tool(self, tool: Tool) -> None:
+    def load_tool(self, tool: BaseTool) -> None:
         self._tool_manager.add_tool(tool)
 
-    def unload_tool(self, tool: Tool) -> None:
+    def unload_tool(self, tool: BaseTool) -> None:
         self._tool_manager.remove_tool(tool)
 
     def reset_memory(self) -> None:
@@ -225,7 +226,7 @@ class Agent(BaseAgent):
         await self._callback_manager.on_llm_end(agent=self, llm=self.llm, response=llm_resp)
         return llm_resp
 
-    async def _async_run_tool_without_hooks(self, tool: Tool, tool_args: str) -> ToolResponse:
+    async def _async_run_tool_without_hooks(self, tool: BaseTool, tool_args: str) -> ToolResponse:
         parsed_tool_args = self._parse_tool_args(tool_args)
         # XXX: Sniffing is less efficient and probably unnecessary.
         # Can we make a protocol to statically recognize file inputs and outputs
@@ -253,7 +254,7 @@ class Agent(BaseAgent):
         return args_dict
 
     async def _sniff_and_extract_files_from_args(
-        self, args: Dict[str, Any], tool: Tool, file_type: Literal["input", "output"]
+        self, args: Dict[str, Any], tool: BaseTool, file_type: Literal["input", "output"]
     ) -> List[AgentFile]:
         agent_files: List[AgentFile] = []
         for val in args.values():

--- a/erniebot-agent/erniebot_agent/agents/callback/callback_manager.py
+++ b/erniebot-agent/erniebot_agent/agents/callback/callback_manager.py
@@ -22,7 +22,7 @@ from erniebot_agent.agents.callback.handlers.base import CallbackHandler
 from erniebot_agent.agents.schema import AgentResponse, LLMResponse, ToolResponse
 from erniebot_agent.chat_models.base import ChatModel
 from erniebot_agent.messages import Message
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 
 if TYPE_CHECKING:
     from erniebot_agent.agents.base import Agent
@@ -79,14 +79,14 @@ class CallbackManager(object):
     ) -> None:
         await self.handle_event(EventType.LLM_ERROR, agent=agent, llm=llm, error=error)
 
-    async def on_tool_start(self, agent: Agent, tool: Tool, input_args: str) -> None:
+    async def on_tool_start(self, agent: Agent, tool: BaseTool, input_args: str) -> None:
         await self.handle_event(EventType.TOOL_START, agent=agent, tool=tool, input_args=input_args)
 
-    async def on_tool_end(self, agent: Agent, tool: Tool, response: ToolResponse) -> None:
+    async def on_tool_end(self, agent: Agent, tool: BaseTool, response: ToolResponse) -> None:
         await self.handle_event(EventType.TOOL_END, agent=agent, tool=tool, response=response)
 
     async def on_tool_error(
-        self, agent: Agent, tool: Tool, error: Union[Exception, KeyboardInterrupt]
+        self, agent: Agent, tool: BaseTool, error: Union[Exception, KeyboardInterrupt]
     ) -> None:
         await self.handle_event(EventType.TOOL_ERROR, agent=agent, tool=tool, error=error)
 

--- a/erniebot-agent/erniebot_agent/agents/callback/handlers/base.py
+++ b/erniebot-agent/erniebot_agent/agents/callback/handlers/base.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, List, Union
 from erniebot_agent.agents.schema import AgentResponse, LLMResponse, ToolResponse
 from erniebot_agent.chat_models.base import ChatModel
 from erniebot_agent.messages import Message
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 
 if TYPE_CHECKING:
     from erniebot_agent.agents.base import Agent
@@ -40,14 +40,14 @@ class CallbackHandler(object):
     ) -> None:
         """"""
 
-    async def on_tool_start(self, agent: Agent, tool: Tool, input_args: str) -> None:
+    async def on_tool_start(self, agent: Agent, tool: BaseTool, input_args: str) -> None:
         """"""
 
-    async def on_tool_end(self, agent: Agent, tool: Tool, response: ToolResponse) -> None:
+    async def on_tool_end(self, agent: Agent, tool: BaseTool, response: ToolResponse) -> None:
         """"""
 
     async def on_tool_error(
-        self, agent: Agent, tool: Tool, error: Union[Exception, KeyboardInterrupt]
+        self, agent: Agent, tool: BaseTool, error: Union[Exception, KeyboardInterrupt]
     ) -> None:
         """"""
 

--- a/erniebot-agent/erniebot_agent/agents/callback/handlers/logging_handler.py
+++ b/erniebot-agent/erniebot_agent/agents/callback/handlers/logging_handler.py
@@ -21,7 +21,7 @@ from erniebot_agent.agents.callback.handlers.base import CallbackHandler
 from erniebot_agent.agents.schema import AgentResponse, LLMResponse, ToolResponse
 from erniebot_agent.chat_models.base import ChatModel
 from erniebot_agent.messages import Message
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 from erniebot_agent.utils.json import to_pretty_json
 from erniebot_agent.utils.logging import logger as default_logger
 from erniebot_agent.utils.output_style import color_msg, color_text
@@ -81,7 +81,7 @@ class LoggingHandler(CallbackHandler):
     ) -> None:
         pass
 
-    async def on_tool_start(self, agent: Agent, tool: Tool, input_args: str) -> None:
+    async def on_tool_start(self, agent: Agent, tool: BaseTool, input_args: str) -> None:
         js_inputs = to_pretty_json(input_args, from_json=True)
         self.agent_info(
             "%s is about to start running with input:\n%s\n",
@@ -91,7 +91,7 @@ class LoggingHandler(CallbackHandler):
             state="Start",
         )
 
-    async def on_tool_end(self, agent: Agent, tool: Tool, response: ToolResponse) -> None:
+    async def on_tool_end(self, agent: Agent, tool: BaseTool, response: ToolResponse) -> None:
         js_inputs = to_pretty_json(response.json, from_json=True)
         self.agent_info(
             "%s finished running with output:\n%s\n",
@@ -102,7 +102,7 @@ class LoggingHandler(CallbackHandler):
         )
 
     async def on_tool_error(
-        self, agent: Agent, tool: Tool, error: Union[Exception, KeyboardInterrupt]
+        self, agent: Agent, tool: BaseTool, error: Union[Exception, KeyboardInterrupt]
     ) -> None:
         pass
 

--- a/erniebot-agent/erniebot_agent/agents/functional_agent.py
+++ b/erniebot-agent/erniebot_agent/agents/functional_agent.py
@@ -28,7 +28,7 @@ from erniebot_agent.messages import (
     Message,
     SystemMessage,
 )
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 
 _MAX_STEPS = 5
 
@@ -37,7 +37,7 @@ class FunctionalAgent(Agent):
     def __init__(
         self,
         llm: ChatModel,
-        tools: Union[ToolManager, List[Tool]],
+        tools: Union[ToolManager, List[BaseTool]],
         memory: Memory,
         system_message: Optional[SystemMessage] = None,
         *,

--- a/erniebot-agent/erniebot_agent/tools/tool_manager.py
+++ b/erniebot-agent/erniebot_agent/tools/tool_manager.py
@@ -15,7 +15,7 @@
 import json
 from typing import Dict, List, final
 
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 
 
 @final
@@ -26,22 +26,22 @@ class ToolManager(object):
     https://github.com/deepset-ai/haystack/blob/main/haystack/agents/base.py
     """
 
-    def __init__(self, tools: List[Tool]) -> None:
+    def __init__(self, tools: List[BaseTool]) -> None:
         super().__init__()
-        self._tools: Dict[str, Tool] = {}
+        self._tools: Dict[str, BaseTool] = {}
         for tool in tools:
             self.add_tool(tool)
 
-    def __getitem__(self, tool_name: str) -> Tool:
+    def __getitem__(self, tool_name: str) -> BaseTool:
         return self.get_tool(tool_name)
 
-    def add_tool(self, tool: Tool) -> None:
+    def add_tool(self, tool: BaseTool) -> None:
         tool_name = tool.tool_name
         if tool_name in self._tools:
             raise RuntimeError(f"Name {repr(tool_name)} is already registered.")
         self._tools[tool_name] = tool
 
-    def remove_tool(self, tool: Tool) -> None:
+    def remove_tool(self, tool: BaseTool) -> None:
         tool_name = tool.tool_name
         if tool_name not in self._tools:
             raise RuntimeError(f"Name {repr(tool_name)} is not registered.")
@@ -49,12 +49,12 @@ class ToolManager(object):
             raise RuntimeError(f"The tool with the registered name {repr(tool_name)} is not the given tool.")
         self._tools.pop(tool_name)
 
-    def get_tool(self, tool_name: str) -> Tool:
+    def get_tool(self, tool_name: str) -> BaseTool:
         if tool_name not in self._tools:
             raise RuntimeError(f"Name {repr(tool_name)} is not registered.")
         return self._tools[tool_name]
 
-    def get_tools(self) -> List[Tool]:
+    def get_tools(self) -> List[BaseTool]:
         return list(self._tools.values())
 
     def get_tool_names(self) -> str:

--- a/erniebot-agent/examples/rpg_game_agent.py
+++ b/erniebot-agent/examples/rpg_game_agent.py
@@ -28,7 +28,7 @@ from erniebot_agent.file_io.base import File
 from erniebot_agent.file_io.file_manager import FileManager
 from erniebot_agent.memory.sliding_window_memory import SlidingWindowMemory
 from erniebot_agent.messages import AIMessage, HumanMessage, SystemMessage
-from erniebot_agent.tools.base import Tool
+from erniebot_agent.tools.base import BaseTool
 from erniebot_agent.tools.ImageGenerateTool import (
     ImageGenerationTool,  # 目前为remotetool，如做直接展示可以替换为yinian
 )
@@ -72,7 +72,7 @@ class GameAgent(Agent):
         self,
         model: str,
         script: str,
-        tools: Union[ToolManager, List[Tool]],
+        tools: Union[ToolManager, List[BaseTool]],
         system_message: Optional[SystemMessage] = None,
         access_token: Union[str, None] = None,
         max_round: int = 3,

--- a/erniebot-agent/tests/unit_tests/testing_utils/mocks/mock_tool.py
+++ b/erniebot-agent/tests/unit_tests/testing_utils/mocks/mock_tool.py
@@ -19,14 +19,6 @@ class FakeTool(BaseTool):
         return self.name
 
     @property
-    def input_type(self):
-        raise AttributeError("`input_type` is not yet supported.")
-
-    @property
-    def output_type(self):
-        raise AttributeError("`output_type` is not yet supported.")
-
-    @property
     def examples(self):
         return []
 


### PR DESCRIPTION
之前我误以为`Tool`是处理所有工具的抽象类，但实际上`Tool`对应的应该是本地工具，而`BaseTool`才是接口。为此，做了如下修改：

1. 使`ToolManager`和`Agent`依赖于`BaseTool`而不是`Tool`，理由是显然的：这两个类也需要处理远程工具。
2. 将`Tool`和`RemoteTool`中事实存在的属性约束（需要具有只读属性`tool_name`和`messages`）显式定义在接口里。
3. 由于`RemoteTool.__call__`返回的类型为`Any`，在agent中添加相应检查，当输出不为字典时不嗅探和提取文件ID。