### PR TITLE
[Agent][Feat] Support short-lived URL generation API

### DIFF
--- a/erniebot-agent/erniebot_agent/agents/functional_agent.py
+++ b/erniebot-agent/erniebot_agent/agents/functional_agent.py
@@ -67,10 +67,12 @@ class FunctionalAgent(Agent):
         actions_taken: List[AgentAction] = []
         files_involved: List[AgentFile] = []
 
-        ask = HumanMessage(content=prompt, files=files, include_file_url=self.file_needs_url)
+        run_input = await HumanMessage.create_with_files(
+            prompt, files or [], include_file_urls=self.file_needs_url
+        )
 
         num_steps_taken = 0
-        next_step_input: Message = ask
+        next_step_input: Message = run_input
         while num_steps_taken < self.max_steps:
             curr_step_output = await self._async_step(
                 next_step_input,

--- a/erniebot-agent/erniebot_agent/file_io/base.py
+++ b/erniebot-agent/erniebot_agent/file_io/base.py
@@ -46,15 +46,15 @@ class File(metaclass=abc.ABCMeta):
         attrs_str = self._get_attrs_str()
         return f"<{self.__class__.__name__} {attrs_str}>"
 
-    def file_repr(self) -> str:
+    @abc.abstractmethod
+    async def read_contents(self) -> bytes:
+        raise NotImplementedError
+
+    def get_file_repr(self) -> str:
         return f"<file>{self.id}</file>"
 
     def to_dict(self) -> dict:
         return {k: getattr(self, k) for k in self._param_names}
-
-    @abc.abstractmethod
-    async def read_contents(self) -> bytes:
-        raise NotImplementedError
 
     def _get_attrs_str(self) -> str:
         return ", ".join(

--- a/erniebot-agent/erniebot_agent/file_io/remote_file.py
+++ b/erniebot-agent/erniebot_agent/file_io/remote_file.py
@@ -54,7 +54,7 @@ class RemoteFile(File):
     async def delete(self) -> None:
         await self._client.delete_file(self.id)
 
-    async def create_temporary_url(self, expire_after: float = 1800) -> str:
+    async def create_temporary_url(self, expire_after: float = 600) -> str:
         return await self._client.create_temporary_url(self.id, expire_after)
 
     def get_file_repr_with_url(self, url: str) -> str:


### PR DESCRIPTION
当前采用简单策略，agent每次run之前向服务器请求创建URL。该方案的优点是不需要维护`RemoteFile`的状态（当前`File`被设计为不可变对象），避免引入复杂的缓存逻辑；缺点是每次都需要请求。

TODO:

- [ ] 添加单测。