### PR TITLE
[New Feature] 支持 stream agent 流式返回step和message

### DIFF
--- a/erniebot-agent/src/erniebot_agent/agents/agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/agent.py
@@ -299,7 +299,8 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         prompt and optionally accompanying files.
         """
         if False:
-            # This conditional block is strictly for static type-checking purposes (e.g., mypy) and will not be executed.
+            # This conditional block is strictly for static type-checking purposes (e.g., mypy)
+            # and will not be executed.
             only_for_mypy_type_check: Tuple[AgentStep, List[Message]] = (DEFAULT_FINISH_STEP, [])
             yield only_for_mypy_type_check
 

--- a/erniebot-agent/src/erniebot_agent/agents/agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/agent.py
@@ -2,6 +2,7 @@ import abc
 import json
 import logging
 from typing import (
+    AsyncIterator,
     Any,
     Dict,
     Final,
@@ -20,7 +21,7 @@ from erniebot_agent.agents.callback.callback_manager import CallbackManager
 from erniebot_agent.agents.callback.default import get_default_callbacks
 from erniebot_agent.agents.callback.handlers.base import CallbackHandler
 from erniebot_agent.agents.mixins import GradioMixin
-from erniebot_agent.agents.schema import AgentResponse, LLMResponse, ToolResponse
+from erniebot_agent.agents.schema import AgentResponse, LLMResponse, ToolResponse, AgentStep
 from erniebot_agent.chat_models.erniebot import BaseERNIEBot
 from erniebot_agent.file import (
     File,
@@ -132,6 +133,30 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         return agent_resp
 
     @final
+    async def run_stream(self, prompt: str, files: Optional[Sequence[File]] = None) -> AsyncIterator[AgentStep]:
+        """Run the agent asynchronously.
+
+        Args:
+            prompt: A natural language text describing the task that the agent
+                should perform.
+            files: A list of files that the agent can use to perform the task.
+        Returns:
+            Response AgentStep from the agent.
+        """
+        if files:
+            await self._ensure_managed_files(files)
+        await self._callback_manager.on_run_start(agent=self, prompt=prompt)
+        try:
+            async for step in self._run_stream(prompt, files):
+                yield step
+        except BaseException as e:
+            await self._callback_manager.on_run_error(agent=self, error=e)
+            raise e
+        else:
+            await self._callback_manager.on_run_end(agent=self, response=None)
+        return
+
+    @final
     async def run_llm(
         self,
         messages: List[Message],
@@ -155,6 +180,36 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         else:
             await self._callback_manager.on_llm_end(agent=self, llm=self.llm, response=llm_resp)
         return llm_resp
+        
+
+    @final
+    async def run_llm_stream(
+        self,
+        messages: List[Message],
+        **llm_opts: Any,
+    ) -> AsyncIterator[LLMResponse]:
+        """Run the LLM asynchronously.
+
+        Args:
+            messages: The input messages.
+            llm_opts: Options to pass to the LLM.
+
+        Returns:
+            Response from the LLM.
+        """
+        llm_resp = None
+        await self._callback_manager.on_llm_start(agent=self, llm=self.llm, messages=messages)
+        try:
+            # The LLM will return an async iterator.
+            async for llm_resp in self._run_llm_stream(messages, **(llm_opts or {})):
+                yield llm_resp
+        except (Exception, KeyboardInterrupt) as e:
+            await self._callback_manager.on_llm_error(agent=self, llm=self.llm, error=e)
+            raise e
+        else:
+            await self._callback_manager.on_llm_end(agent=self, llm=self.llm, response=llm_resp)
+        return
+        
 
     @final
     async def run_tool(self, tool_name: str, tool_args: str) -> ToolResponse:
@@ -221,6 +276,10 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
     async def _run(self, prompt: str, files: Optional[Sequence[File]] = None) -> AgentResponse:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    async def _run_stream(self, prompt: str, files: Optional[Sequence[File]] = None) -> AsyncIterator[AgentStep]:
+        raise NotImplementedError
+    
     async def _run_llm(self, messages: List[Message], **opts: Any) -> LLMResponse:
         for reserved_opt in ("stream", "system", "plugins"):
             if reserved_opt in opts:
@@ -240,6 +299,29 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         opts["plugins"] = self._plugins
         llm_ret = await self.llm.chat(messages, stream=False, functions=functions, **opts)
         return LLMResponse(message=llm_ret)
+        
+
+    async def _run_llm_stream(self, messages: List[Message], **opts: Any) -> AsyncIterator[LLMResponse]:
+        for reserved_opt in ("stream", "system", "plugins"):
+            if reserved_opt in opts:
+                raise TypeError(f"`{reserved_opt}` should not be set.")
+
+        if "functions" not in opts:
+            functions = self._tool_manager.get_tool_schemas()
+        else:
+            functions = opts.pop("functions")
+
+        if hasattr(self.llm, "system"):
+            _logger.warning(
+                "The `system` message has already been set in the agent;"
+                "the `system` message configured in ERNIEBot will become ineffective."
+            )
+        opts["system"] = self.system.content if self.system is not None else None
+        opts["plugins"] = self._plugins
+        llm_ret = await self.llm.chat(messages, stream=True, functions=functions, **opts)
+        async for msg in llm_ret:
+            yield LLMResponse(message=msg)
+
 
     async def _run_tool(self, tool: BaseTool, tool_args: str) -> ToolResponse:
         parsed_tool_args = self._parse_tool_args(tool_args)

--- a/erniebot-agent/src/erniebot_agent/agents/agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/agent.py
@@ -2,8 +2,8 @@ import abc
 import json
 import logging
 from typing import (
-    AsyncIterator,
     Any,
+    AsyncIterator,
     Dict,
     Final,
     Iterable,
@@ -21,7 +21,12 @@ from erniebot_agent.agents.callback.callback_manager import CallbackManager
 from erniebot_agent.agents.callback.default import get_default_callbacks
 from erniebot_agent.agents.callback.handlers.base import CallbackHandler
 from erniebot_agent.agents.mixins import GradioMixin
-from erniebot_agent.agents.schema import AgentResponse, LLMResponse, ToolResponse, AgentStep
+from erniebot_agent.agents.schema import (
+    AgentResponse,
+    AgentStep,
+    LLMResponse,
+    ToolResponse,
+)
 from erniebot_agent.chat_models.erniebot import BaseERNIEBot
 from erniebot_agent.file import (
     File,

--- a/erniebot-agent/src/erniebot_agent/agents/agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/agent.py
@@ -2,6 +2,7 @@ import abc
 import json
 import logging
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Dict,
@@ -298,7 +299,8 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         This method should yield a sequence of (AgentStep, List[Message]) tuples based on the given
         prompt and optionally accompanying files.
         """
-        if False:
+        if TYPE_CHECKING:
+            # HACK
             # This conditional block is strictly for static type-checking purposes (e.g., mypy)
             # and will not be executed.
             only_for_mypy_type_check: Tuple[AgentStep, List[Message]] = (DEFAULT_FINISH_STEP, [])

--- a/erniebot-agent/src/erniebot_agent/agents/agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/agent.py
@@ -142,14 +142,14 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
     async def run_stream(
         self, prompt: str, files: Optional[Sequence[File]] = None
     ) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
-        """Run the agent asynchronously.
+        """Run the agent asynchronously, returning an async iterator of responses.
 
         Args:
             prompt: A natural language text describing the task that the agent
                 should perform.
             files: A list of files that the agent can use to perform the task.
         Returns:
-            Response AgentStep from the agent.
+            Iterator of responses from the agent.
         """
         if files:
             await self._ensure_managed_files(files)
@@ -164,7 +164,7 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
             await self._callback_manager.on_run_end(
                 agent=self,
                 response=AgentResponse(
-                    text="Agent run stopped early.",
+                    text="Agent run stopped.",
                     chat_history=self.memory.get_messages(),
                     steps=[step],
                     status="STOPPED",
@@ -177,7 +177,7 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         messages: List[Message],
         **llm_opts: Any,
     ) -> LLMResponse:
-        """Run the LLM asynchronously.
+        """Run the LLM asynchronously, returning final response.
 
         Args:
             messages: The input messages.
@@ -202,14 +202,14 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         messages: List[Message],
         **llm_opts: Any,
     ) -> AsyncIterator[LLMResponse]:
-        """Run the LLM asynchronously.
+        """Run the LLM asynchronously, returning an async iterator of responses
 
         Args:
             messages: The input messages.
             llm_opts: Options to pass to the LLM.
 
         Returns:
-            Response from the LLM.
+            Iterator of responses from the LLM.
         """
         llm_resp = None
         await self._callback_manager.on_llm_start(agent=self, llm=self.llm, messages=messages)
@@ -305,6 +305,15 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
             yield only_for_mypy_type_check
 
     async def _run_llm(self, messages: List[Message], **opts: Any) -> LLMResponse:
+        """Run the LLM with the given messages and options.
+
+        Args:
+            messages: The input messages.
+            opts: Options to pass to the LLM.
+
+        Returns:
+            Response from the LLM.
+        """
         for reserved_opt in ("stream", "system", "plugins"):
             if reserved_opt in opts:
                 raise TypeError(f"`{reserved_opt}` should not be set.")
@@ -325,6 +334,15 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         return LLMResponse(message=llm_ret)
 
     async def _run_llm_stream(self, messages: List[Message], **opts: Any) -> AsyncIterator[LLMResponse]:
+        """Run the LLM, yielding an async iterator of responses.
+
+        Args:
+            messages: The input messages.
+            opts: Options to pass to the LLM.
+
+        Returns:
+            Async iterator of responses from the LLM.
+        """
         for reserved_opt in ("stream", "system", "plugins"):
             if reserved_opt in opts:
                 raise TypeError(f"`{reserved_opt}` should not be set.")

--- a/erniebot-agent/src/erniebot_agent/agents/agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/agent.py
@@ -133,7 +133,9 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         return agent_resp
 
     @final
-    async def run_stream(self, prompt: str, files: Optional[Sequence[File]] = None) -> AsyncIterator[AgentStep]:
+    async def run_stream(
+        self, prompt: str, files: Optional[Sequence[File]] = None
+    ) -> AsyncIterator[AgentStep]:
         """Run the agent asynchronously.
 
         Args:
@@ -180,7 +182,6 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         else:
             await self._callback_manager.on_llm_end(agent=self, llm=self.llm, response=llm_resp)
         return llm_resp
-        
 
     @final
     async def run_llm_stream(
@@ -209,7 +210,6 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         else:
             await self._callback_manager.on_llm_end(agent=self, llm=self.llm, response=llm_resp)
         return
-        
 
     @final
     async def run_tool(self, tool_name: str, tool_args: str) -> ToolResponse:
@@ -277,9 +277,11 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    async def _run_stream(self, prompt: str, files: Optional[Sequence[File]] = None) -> AsyncIterator[AgentStep]:
+    async def _run_stream(
+        self, prompt: str, files: Optional[Sequence[File]] = None
+    ) -> AsyncIterator[AgentStep]:
         raise NotImplementedError
-    
+
     async def _run_llm(self, messages: List[Message], **opts: Any) -> LLMResponse:
         for reserved_opt in ("stream", "system", "plugins"):
             if reserved_opt in opts:
@@ -299,7 +301,6 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         opts["plugins"] = self._plugins
         llm_ret = await self.llm.chat(messages, stream=False, functions=functions, **opts)
         return LLMResponse(message=llm_ret)
-        
 
     async def _run_llm_stream(self, messages: List[Message], **opts: Any) -> AsyncIterator[LLMResponse]:
         for reserved_opt in ("stream", "system", "plugins"):
@@ -321,7 +322,6 @@ class Agent(GradioMixin, BaseAgent[BaseERNIEBot]):
         llm_ret = await self.llm.chat(messages, stream=True, functions=functions, **opts)
         async for msg in llm_ret:
             yield LLMResponse(message=msg)
-
 
     async def _run_tool(self, tool: BaseTool, tool_args: str) -> ToolResponse:
         parsed_tool_args = self._parse_tool_args(tool_args)

--- a/erniebot-agent/src/erniebot_agent/agents/function_agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/function_agent.py
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 import logging
-from typing import Final, Iterable, List, Optional, Sequence, Tuple, Union, AsyncIterator
+from typing import (
+    AsyncIterator,
+    Final,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from erniebot_agent.agents.agent import Agent
 from erniebot_agent.agents.callback.callback_manager import CallbackManager
@@ -31,7 +40,12 @@ from erniebot_agent.agents.schema import (
 from erniebot_agent.chat_models.erniebot import BaseERNIEBot
 from erniebot_agent.file import File, FileManager
 from erniebot_agent.memory import Memory
-from erniebot_agent.memory.messages import FunctionMessage, HumanMessage, Message, AIMessage
+from erniebot_agent.memory.messages import (
+    AIMessage,
+    FunctionMessage,
+    HumanMessage,
+    Message,
+)
 from erniebot_agent.tools.base import BaseTool
 from erniebot_agent.tools.tool_manager import ToolManager
 

--- a/erniebot-agent/src/erniebot_agent/agents/function_agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/function_agent.py
@@ -166,7 +166,6 @@ class FunctionAgent(Agent):
             num_steps_taken += 1
         response = self._create_stopped_response(chat_history, steps_taken)
         return response
-    
 
     async def _first_tool_step(
         self, chat_history: List[Message], selected_tool: BaseTool = None
@@ -184,7 +183,6 @@ class FunctionAgent(Agent):
         )
         return await self._schema_format(llm_resp, chat_history)
 
-
     async def _step(self, chat_history: List[Message]) -> Tuple[AgentStep, List[Message]]:
         """Run a step of the agent.
         Args:
@@ -196,8 +194,9 @@ class FunctionAgent(Agent):
         llm_resp = await self.run_llm(messages=input_messages)
         return await self._schema_format(llm_resp, chat_history)
 
-
-    async def _step_stream(self, chat_history: List[Message]) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
+    async def _step_stream(
+        self, chat_history: List[Message]
+    ) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
         """Run a step of the agent in streaming mode.
         Args:
             chat_history: The chat history to provide to the agent.
@@ -208,8 +207,9 @@ class FunctionAgent(Agent):
         async for llm_resp in self.run_llm_stream(messages=input_messages):
             yield await self._schema_format(llm_resp, chat_history)
 
-
-    async def _run_stream(self, prompt: str, files: Optional[Sequence[File]] = None) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
+    async def _run_stream(
+        self, prompt: str, files: Optional[Sequence[File]] = None
+    ) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
         """Run the agent with the given prompt and files in streaming mode.
         Args:
             prompt: The prompt for the agent to run.
@@ -259,7 +259,7 @@ class FunctionAgent(Agent):
                     # 此处为调用了Plugin之后直接结束的Plugin
                     curr_step = DEFAULT_FINISH_STEP
                     yield curr_step, new_messages
-                        
+
                 if isinstance(curr_step, EndStep):
                     is_finished = True
                     end_step_msgs.extend(new_messages)
@@ -269,7 +269,6 @@ class FunctionAgent(Agent):
         self.memory.add_message(run_input)
         end_step_msg = AIMessage(content="".join([item.content for item in end_step_msgs]))
         self.memory.add_message(end_step_msg)
-
 
     async def _schema_format(self, llm_resp, chat_history):
         """Convert the LLM response to the agent response schema.

--- a/erniebot-agent/src/erniebot_agent/agents/function_agent.py
+++ b/erniebot-agent/src/erniebot_agent/agents/function_agent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Final, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Final, Iterable, List, Optional, Sequence, Tuple, Union, AsyncIterator
 
 from erniebot_agent.agents.agent import Agent
 from erniebot_agent.agents.callback.callback_manager import CallbackManager
@@ -31,7 +31,7 @@ from erniebot_agent.agents.schema import (
 from erniebot_agent.chat_models.erniebot import BaseERNIEBot
 from erniebot_agent.file import File, FileManager
 from erniebot_agent.memory import Memory
-from erniebot_agent.memory.messages import FunctionMessage, HumanMessage, Message
+from erniebot_agent.memory.messages import FunctionMessage, HumanMessage, Message, AIMessage
 from erniebot_agent.tools.base import BaseTool
 from erniebot_agent.tools.tool_manager import ToolManager
 
@@ -136,7 +136,7 @@ class FunctionAgent(Agent):
         chat_history.append(run_input)
 
         for tool in self._first_tools:
-            curr_step, new_messages = await self._step(chat_history, selected_tool=tool)
+            curr_step, new_messages = await self._first_tool_step(chat_history, selected_tool=tool)
             if not isinstance(curr_step, EndStep):
                 chat_history.extend(new_messages)
                 num_steps_taken += 1
@@ -166,22 +166,120 @@ class FunctionAgent(Agent):
             num_steps_taken += 1
         response = self._create_stopped_response(chat_history, steps_taken)
         return response
+    
 
-    async def _step(
-        self, chat_history: List[Message], selected_tool: Optional[BaseTool] = None
+    async def _first_tool_step(
+        self, chat_history: List[Message], selected_tool: BaseTool = None
     ) -> Tuple[AgentStep, List[Message]]:
-        new_messages: List[Message] = []
         input_messages = self.memory.get_messages() + chat_history
-        if selected_tool is not None:
-            tool_choice = {"type": "function", "function": {"name": selected_tool.tool_name}}
-            llm_resp = await self.run_llm(
-                messages=input_messages,
-                functions=[selected_tool.function_call_schema()],  # only regist one tool
-                tool_choice=tool_choice,
-            )
-        else:
+        if selected_tool is None:
             llm_resp = await self.run_llm(messages=input_messages)
+            return await self._schema_format(llm_resp, chat_history)
 
+        tool_choice = {"type": "function", "function": {"name": selected_tool.tool_name}}
+        llm_resp = await self.run_llm(
+            messages=input_messages,
+            functions=[selected_tool.function_call_schema()],  # only regist one tool
+            tool_choice=tool_choice,
+        )
+        return await self._schema_format(llm_resp, chat_history)
+
+
+    async def _step(self, chat_history: List[Message]) -> Tuple[AgentStep, List[Message]]:
+        """Run a step of the agent.
+        Args:
+            chat_history: The chat history to provide to the agent.
+        Returns:
+            A tuple of an agent step and a list of new messages.
+        """
+        input_messages = self.memory.get_messages() + chat_history
+        llm_resp = await self.run_llm(messages=input_messages)
+        return await self._schema_format(llm_resp, chat_history)
+
+
+    async def _step_stream(self, chat_history: List[Message]) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
+        """Run a step of the agent in streaming mode.
+        Args:
+            chat_history: The chat history to provide to the agent.
+        Returns:
+            An async iterator that yields a tuple of an agent step and a list ofnew messages.
+        """
+        input_messages = self.memory.get_messages() + chat_history
+        async for llm_resp in self.run_llm_stream(messages=input_messages):
+            yield await self._schema_format(llm_resp, chat_history)
+
+
+    async def _run_stream(self, prompt: str, files: Optional[Sequence[File]] = None) -> AsyncIterator[Tuple[AgentStep, List[Message]]]:
+        """Run the agent with the given prompt and files in streaming mode.
+        Args:
+            prompt: The prompt for the agent to run.
+            files: A list of files for the agent to use. If `None`, use an empty
+                list.
+        Returns:
+            If `stream` is `False`, an agent response object. If `stream` is
+            `True`, an async iterator that yields agent steps one by one.
+        """
+        chat_history: List[Message] = []
+        steps_taken: List[AgentStep] = []
+
+        run_input = await HumanMessage.create_with_files(
+            prompt, files or [], include_file_urls=self.file_needs_url
+        )
+
+        num_steps_taken = 0
+        chat_history.append(run_input)
+
+        for tool in self._first_tools:
+            curr_step, new_messages = await self._first_tool_step(chat_history, selected_tool=tool)
+            if not isinstance(curr_step, EndStep):
+                chat_history.extend(new_messages)
+                num_steps_taken += 1
+                steps_taken.append(curr_step)
+            else:
+                # If tool choice not work, skip this round
+                _logger.warning(f"Selected tool [{tool.tool_name}] not work")
+
+        is_finished = False
+        curr_step = None
+        new_messages = []
+        end_step_msgs = []
+        while is_finished is False:
+            # IMPORTANT~! We use following code to get the response from LLM
+            # When finish_reason is fuction_call, run_llm_stream return all info in one step, but
+            # When finish_reason is normal chat, run_llm_stream return info in multiple steps.
+            async for curr_step, new_messages in self._step_stream(chat_history):
+                if isinstance(curr_step, ToolStep):
+                    steps_taken.append(curr_step)
+                    yield curr_step, new_messages
+
+                elif isinstance(curr_step, PluginStep):
+                    steps_taken.append(curr_step)
+                    # 预留 调用了Plugin之后不结束的接口
+
+                    # 此处为调用了Plugin之后直接结束的Plugin
+                    curr_step = DEFAULT_FINISH_STEP
+                    yield curr_step, new_messages
+                        
+                if isinstance(curr_step, EndStep):
+                    is_finished = True
+                    end_step_msgs.extend(new_messages)
+                    yield curr_step, new_messages
+            chat_history.extend(new_messages)
+
+        self.memory.add_message(run_input)
+        end_step_msg = AIMessage(content="".join([item.content for item in end_step_msgs]))
+        self.memory.add_message(end_step_msg)
+
+
+    async def _schema_format(self, llm_resp, chat_history):
+        """Convert the LLM response to the agent response schema.
+        Args:
+            llm_resp: The LLM response to convert.
+            chat_history: The chat history to provide to the agent.
+        Returns:
+            A tuple of an agent step and a list of new messages.
+        """
+        new_messages: List[Message] = []
         output_message = llm_resp.message  # AIMessage
         new_messages.append(output_message)
         if output_message.function_call is not None:

--- a/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
+++ b/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
@@ -76,7 +76,7 @@ async def test_function_agent_run_no_hit(llm, tool, memory):
 
     tool_steps = [step for step, msgs in run_logs if not isinstance(step, EndStep)]
     assert len(tool_steps) == 0
-    
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("prompt", [ONE_HIT_PROMPT, NO_HIT_PROMPT])

--- a/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
+++ b/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
@@ -1,0 +1,97 @@
+import json
+
+import pytest
+
+from erniebot_agent.agents import FunctionAgent
+from erniebot_agent.chat_models import ERNIEBot
+from erniebot_agent.memory import WholeMemory
+from erniebot_agent.memory.messages import AIMessage, AIMessageChunk, FunctionMessage, HumanMessage
+from erniebot_agent.tools.calculator_tool import CalculatorTool
+
+ONE_HIT_PROMPT = "1+4等于几？"
+NO_HIT_PROMPT = "深圳今天天气怎么样？"
+
+# cd ERNIE-SDK/erniebot-agent/tests
+# EB_AGENT_ACCESS_TOKEN=<token> pytest integration_tests/agents/test_functional_agent_stream.py -s
+
+@pytest.fixture(scope="module")
+def llm():
+    return ERNIEBot(model="ernie-3.5")
+
+
+@pytest.fixture(scope="module")
+def tool():
+    return CalculatorTool()
+
+
+@pytest.fixture(scope="function")
+def memory():
+    return WholeMemory()
+
+
+@pytest.mark.asyncio
+async def test_function_agent_run_one_hit(llm, tool, memory):
+    agent = FunctionAgent(llm=llm, tools=[tool], memory=memory)
+    prompt = ONE_HIT_PROMPT
+
+    run_logs = []
+    async for step, msgs in agent.run_stream(prompt):
+       run_logs.append((step, msgs))
+
+    assert len(agent.memory.get_messages()) == 2
+    assert isinstance(agent.memory.get_messages()[0], HumanMessage)
+    assert agent.memory.get_messages()[0].content == prompt
+    assert isinstance(run_logs[0][1][0], AIMessageChunk)
+    assert run_logs[0][1][0].function_call is not None
+    assert run_logs[0][1][0].function_call["name"] == tool.tool_name
+    assert isinstance(run_logs[0][1][1], FunctionMessage)
+    assert run_logs[0][1][1].name == run_logs[0][1][0].function_call["name"]
+    assert json.loads(run_logs[0][1][1].content) == {"formula_result": 5}
+    assert isinstance(agent.memory.get_messages()[1], AIMessage)
+    
+    steps = [step for step, msgs in run_logs if step.__class__.__name__ != "EndStep"]
+    assert len(steps) == 1
+    assert steps[0].info["tool_name"] == tool.tool_name
+
+@pytest.mark.asyncio
+async def test_function_agent_run_no_hit(llm, tool, memory):
+    agent = FunctionAgent(llm=llm, tools=[tool], memory=memory)
+    prompt = NO_HIT_PROMPT
+
+    run_logs = []
+    async for step, msgs in agent.run_stream(prompt):
+        run_logs.append((step, msgs))
+
+    assert len(agent.memory.get_messages()) == 2
+    assert isinstance(agent.memory.get_messages()[0], HumanMessage)
+    assert agent.memory.get_messages()[0].content == prompt
+    assert isinstance(run_logs[0][1][0], AIMessage)
+    end_step_msg = "".join([msg[0].content for step, msg in run_logs if step.__class__.__name__ == "EndStep"])
+    assert end_step_msg == agent.memory.get_messages()[1].content
+
+    steps = [step for step, msgs in run_logs if step.__class__.__name__ != "EndStep"]
+    assert len(steps) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prompt", [ONE_HIT_PROMPT, NO_HIT_PROMPT])
+async def test_function_agent_run_no_tool(llm, memory, prompt):
+    agent = FunctionAgent(llm=llm, tools=[], memory=memory)
+
+    run_logs = []
+    async for step, msgs in agent.run_stream(prompt):
+        run_logs.append((step, msgs))
+
+    assert len(agent.memory.get_messages()) == 2
+    assert isinstance(agent.memory.get_messages()[0], HumanMessage)
+    assert agent.memory.get_messages()[0].content == prompt
+    assert isinstance(run_logs[0][1][0], AIMessage)
+    end_step_msg = "".join([msg[0].content for step, msg in run_logs if step.__class__.__name__ == "EndStep"])
+    assert end_step_msg == agent.memory.get_messages()[1].content
+
+    steps = [step for step, msgs in run_logs if step.__class__.__name__ != "EndStep"]
+    assert len(steps) == 0
+
+
+    
+

--- a/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
+++ b/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
@@ -5,7 +5,12 @@ import pytest
 from erniebot_agent.agents import FunctionAgent
 from erniebot_agent.chat_models import ERNIEBot
 from erniebot_agent.memory import WholeMemory
-from erniebot_agent.memory.messages import AIMessage, AIMessageChunk, FunctionMessage, HumanMessage
+from erniebot_agent.memory.messages import (
+    AIMessage,
+    AIMessageChunk,
+    FunctionMessage,
+    HumanMessage,
+)
 from erniebot_agent.tools.calculator_tool import CalculatorTool
 
 ONE_HIT_PROMPT = "1+4等于几？"

--- a/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
+++ b/erniebot-agent/tests/integration_tests/agents/test_functional_agent_stream.py
@@ -14,6 +14,7 @@ NO_HIT_PROMPT = "深圳今天天气怎么样？"
 # cd ERNIE-SDK/erniebot-agent/tests
 # EB_AGENT_ACCESS_TOKEN=<token> pytest integration_tests/agents/test_functional_agent_stream.py -s
 
+
 @pytest.fixture(scope="module")
 def llm():
     return ERNIEBot(model="ernie-3.5")
@@ -36,7 +37,7 @@ async def test_function_agent_run_one_hit(llm, tool, memory):
 
     run_logs = []
     async for step, msgs in agent.run_stream(prompt):
-       run_logs.append((step, msgs))
+        run_logs.append((step, msgs))
 
     assert len(agent.memory.get_messages()) == 2
     assert isinstance(agent.memory.get_messages()[0], HumanMessage)
@@ -48,10 +49,11 @@ async def test_function_agent_run_one_hit(llm, tool, memory):
     assert run_logs[0][1][1].name == run_logs[0][1][0].function_call["name"]
     assert json.loads(run_logs[0][1][1].content) == {"formula_result": 5}
     assert isinstance(agent.memory.get_messages()[1], AIMessage)
-    
+
     steps = [step for step, msgs in run_logs if step.__class__.__name__ != "EndStep"]
     assert len(steps) == 1
     assert steps[0].info["tool_name"] == tool.tool_name
+
 
 @pytest.mark.asyncio
 async def test_function_agent_run_no_hit(llm, tool, memory):
@@ -66,7 +68,9 @@ async def test_function_agent_run_no_hit(llm, tool, memory):
     assert isinstance(agent.memory.get_messages()[0], HumanMessage)
     assert agent.memory.get_messages()[0].content == prompt
     assert isinstance(run_logs[0][1][0], AIMessage)
-    end_step_msg = "".join([msg[0].content for step, msg in run_logs if step.__class__.__name__ == "EndStep"])
+    end_step_msg = "".join(
+        [msg[0].content for step, msg in run_logs if step.__class__.__name__ == "EndStep"]
+    )
     assert end_step_msg == agent.memory.get_messages()[1].content
 
     steps = [step for step, msgs in run_logs if step.__class__.__name__ != "EndStep"]
@@ -86,12 +90,10 @@ async def test_function_agent_run_no_tool(llm, memory, prompt):
     assert isinstance(agent.memory.get_messages()[0], HumanMessage)
     assert agent.memory.get_messages()[0].content == prompt
     assert isinstance(run_logs[0][1][0], AIMessage)
-    end_step_msg = "".join([msg[0].content for step, msg in run_logs if step.__class__.__name__ == "EndStep"])
+    end_step_msg = "".join(
+        [msg[0].content for step, msg in run_logs if step.__class__.__name__ == "EndStep"]
+    )
     assert end_step_msg == agent.memory.get_messages()[1].content
 
     steps = [step for step, msgs in run_logs if step.__class__.__name__ != "EndStep"]
     assert len(steps) == 0
-
-
-    
-


### PR DESCRIPTION

> 刚需呀！！

使得`FunctionAgent`支持流式调用，返回`step`和`message`，注意：

* 非`EndStep`会返回一次；
* `EndStep`会返回多次，每次返回新的短句，和`ERNIEBot`的`stream=True`效果相同


```python
from erniebot_agent.agents import FunctionAgent
from erniebot_agent.chat_models import ERNIEBot
from erniebot_agent.memory import WholeMemory
from erniebot_agent.tools.calculator_tool import CalculatorTool


async def agent_stream():
    llm = ERNIEBot(model="ernie-3.5", access_token="<token>")
    memory = WholeMemory()
    agent = FunctionAgent(llm=llm, tools=[CalculatorTool()], memory=memory)
    prompt = "1+4等于几？"
    async for step, msgs in agent.run_stream(prompt):
        print(step, msgs)

import asyncio
asyncio.run(agent_stream())
```

output:
```
ToolStep(info={'tool_name': 'CalculatorTool', 'tool_args': '{"math_formula":"1+4"}'}, result='{"formula_result": 5}', input_files=[], output_files=[]) [<AIMessageChunk role: 'assistant', function_call: {'name': 'CalculatorTool', 'thoughts': '用户询问了1+4的结果，这是一个简单的数学问题，可以使用CalculatorTool工具来计算。', 'arguments': '{"math_formula":"1+4"}'}, token_count: 29>, <FunctionMessage role: 'function', name: 'CalculatorTool', content: '{"formula_result": 5}'>]
EndStep(info={'end_reason': 'FINISHED'}, result=None) [<AIMessageChunk role: 'assistant', content: '根据你的数学', token_count: 0>]
EndStep(info={'end_reason': 'FINISHED'}, result=None) [<AIMessageChunk role: 'assistant', content: '公式1+4，计算结果为5。', token_count: 0>]
EndStep(info={'end_reason': 'FINISHED'}, result=None) [<AIMessageChunk role: 'assistant', content: '如果你还有其他问题或需要执行其他数学公式，请随时告诉我。', token_count: 0>]
EndStep(info={'end_reason': 'FINISHED'}, result=None) [<AIMessageChunk role: 'assistant', token_count: 25>]
```

也有类似的issue需求[#335](https://github.com/PaddlePaddle/ERNIE-SDK/issues/335)


